### PR TITLE
Add script for Frontend Beta

### DIFF
--- a/installers/beta.sh
+++ b/installers/beta.sh
@@ -151,7 +151,7 @@ install-ledfx() {
   python3.9 -m pip install "numpy~=1.20.2" certifi CFFI --no-binary :all:
   echo "Adding" $curruser "to Audio Group"
   sudo usermod -a -G audio $curruser
-  echo "alias ledfx-beta='~/.ledfx/ledfx-beta/bin/python3.9 ~/.ledfx/ledfx-beta/bin/ledfx -c /.ledfx/ledfx-beta/conf -p 8889'" >>~/.bashrc
+  echo "alias ledfx-beta='~/.ledfx/ledfx-beta/bin/python3.9 ~/.ledfx/ledfx-beta/bin/ledfx -c ~/.ledfx/ledfx-beta/conf -p 8889'" >>~/.bashrc
   whiptail --yesno "Install LedFx as a service so it launches automatically on boot?" --yes-button "Yes" --no-button "No" "${r}" "${c}"
   SERVICE=$?
   if [ "$SERVICE" = "0" ]; then


### PR DESCRIPTION
I just adjust the dev script for installing ledfx frontend_beta on Raspberry Pi OS not recommended for other linux os because python3.9 can be install from `apt packages ` on ubuntu plus there is no need to rebuild  `numpy certifi and CFFI` wheel  for ubuntu there is some error if this wheels get pull from https://www.piwheels.org/ on Raspberry Pi OS
The script will install ledfx in `~/.ledfx/ledfx-beta/` directory and run on port `8889` to avoid making conflict on the main ledfx install 
ledfx can be install like `ledfx-beta.service` and can be start just with `ledfx-beta`